### PR TITLE
Refresh library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,14 +31,9 @@ impl Nuban {
         }
     }
 
-    pub fn is_valid(&self) -> Result<bool, bool> {
+    pub fn is_valid(&self) -> bool {
         let check_digit = self.account_number.clone().pop().unwrap();
-
-        if self.calculate_check_digit().unwrap() == check_digit.to_digit(10).unwrap() as u8 {
-            Ok(true)
-        } else {
-            Err(false)
-        }
+        self.calculate_check_digit().unwrap() == check_digit.to_digit(10).unwrap() as u8
     }
 
     pub fn account_number(&self) -> &str {
@@ -126,13 +121,13 @@ mod tests {
     #[test]
     fn test_returns_false_for_invalid_account() {
         let account = Nuban::new("058", "0982736625").unwrap();
-        assert!(account.is_valid().is_err());
+        assert!(!account.is_valid());
     }
 
     #[test]
     fn test_returns_true_for_valid_account() {
         let account = Nuban::new("058", "0152792740").unwrap();
-        assert!(account.is_valid().is_ok());
+        assert!(account.is_valid());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ unsafe impl Sync for LazyBanks {}
 
 static LAZY_BANKS: LazyBanks = LazyBanks(Once::new(), Cell::new(None));
 
-#[derive(PartialEq, Debug)]
+#[derive(Eq, Clone, Debug, PartialEq)]
 pub struct Nuban {
     bank_code: String,
     account_number: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ impl Nuban {
         // convert str to a list of ints to enable calculation
         let number_ints = numbers.chars().map(|num| num.to_digit(10).unwrap());
 
-        let multipliers = vec![3, 7, 3, 3, 7, 3, 3, 7, 3, 3, 7, 3];
+        let multipliers = [3, 7, 3, 3, 7, 3, 3, 7, 3, 3, 7, 3];
         let mut check_sum = 0;
         for (idx, num) in number_ints.enumerate() {
             check_sum += num * multipliers[idx];
@@ -71,7 +71,7 @@ impl Nuban {
     }
 
     pub fn banks(&self) -> HashMap<&str, &str> {
-        let banks: HashMap<&str, &str> = vec![
+        [
             ("044", "Access Bank"),
             ("014", "Afribank"),
             ("023", "Citibank"),
@@ -97,9 +97,9 @@ impl Nuban {
             ("057", "Zenith Bank"),
             ("215", "Unity Bank"),
         ]
-        .into_iter()
-        .collect();
-        banks
+        .iter()
+        .copied()
+        .collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,9 +134,7 @@ impl<'a> Nuban<'a> {
         }
     }
 
-    pub fn bank_matches<'b>(
-        account_number: &'b str,
-    ) -> Result<impl Iterator<Item = (&'b str, &'b str)>, Error> {
+    pub fn bank_matches(account_number: &str) -> Result<impl Iterator<Item = (&str, &str)>, Error> {
         #[rustfmt::skip] if account_number.len() != 10  { Err(Error::InvalidAccountNumber)? };
         Ok(BANKS
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,17 +46,19 @@ impl Nuban {
     }
 
     pub fn calculate_check_digit(&self) -> u8 {
-        // 098273662[5]
-        //           ^= check digit
-        let account_number = &self.account_number[..self.account_number.len() - 1];
-        let numbers = format!("{}{}", self.bank_code, account_number);
+        // The Approved NUBAN format: [ABC][DEFGHIJKL][M], where
+        //   -       ABC : 3-digit Bank Code
+        //   - DEFGHIJKL : NUBAN Account Serial Number
+        //   -         M : NUBAN Check Digit
+        // https://www.cbn.gov.ng/OUT/2011/CIRCULARS/BSPD/NUBAN%20PROPOSALS%20V%200%204-%2003%2009%202010.PDF
+        // let numbers = format!("{}{}", , &self.account_number[..9]);
 
-        let check_sum: u32 = [3, 7, 3, 3, 7, 3, 3, 7, 3, 3, 7, 3]
-            .iter()
-            .zip(numbers.chars().map(|num| num.to_digit(10).unwrap()))
-            .map(|(l, r)| l * r)
-            .sum();
-
+        let bank_code = self.bank_code.chars();
+        let account_number = self.account_number.chars().take(9);
+        let nuban_chars = bank_code.chain(account_number);
+        let nuban_digits = nuban_chars.map(|num| num.to_digit(10).unwrap());
+        let seed = [3, 7, 3, 3, 7, 3, 3, 7, 3, 3, 7, 3].iter();
+        let check_sum: u32 = seed.zip(nuban_digits).map(|(l, r)| l * r).sum();
         match 10 - (check_sum % 10) as u8 {
             10 => 0,
             x => x,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ impl Nuban {
     }
 
     pub fn get_bank_name(&self) -> Result<&str, &str> {
-        let banks = self.banks();
+        let banks = Self::banks();
         let bank_name = banks.get(self.bank_code());
         match bank_name {
             Some(_name) => Ok(bank_name.unwrap()),
@@ -65,7 +65,7 @@ impl Nuban {
         }
     }
 
-    pub fn banks(&self) -> HashMap<&str, &str> {
+    pub fn banks() -> HashMap<&'static str, &'static str> {
         [
             ("044", "Access Bank"),
             ("014", "Afribank"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,9 @@ impl Nuban {
     }
 
     pub fn is_valid(&self) -> bool {
-        let check_digit = self.account_number.clone().pop().unwrap();
-        self.calculate_check_digit() == check_digit.to_digit(10).unwrap() as u8
+        let check_digit = self.account_number.chars().last().unwrap();
+        let check_digit = check_digit.to_digit(10).unwrap() as u8;
+        self.calculate_check_digit() == check_digit
     }
 
     pub fn account_number(&self) -> &str {


### PR DESCRIPTION
- statically define the code-to-bank kv HashMap store (why not just use `lazy_static`? why use it?)
- refactored, removing unnecessary allocations
- added
  - `::bank_matches()`
  - `::is_valid_bank()`
- prevalidate NUBAN, ensuring no invalid `Nuban` definitions
- use structured errors, with descriptive `Display` representations